### PR TITLE
Animated filter

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pretty-quick --pattern "**/*.ts" --staged --check --bail
+npx pretty-quick --pattern "**/*.ts" --staged --check --bail

--- a/README.md
+++ b/README.md
@@ -1,6 +1,105 @@
 gisbot
 ======
 
-Google Image Search slackbot
+A Slack bot that performs Google Image searches directly within Slack.
 
-More to be added later.
+## Features
+
+-   **Simple Commands**: Use `gis [query]` to get an image.
+-   **Image Indexing**: Get the 2nd, 3rd, etc., result by using an index, e.g., `gis2 [query]`.
+-   **Search Modifiers**: Add special modifiers to your search for more specific results:
+    -   `gisa`: Appends "animated gif" to the search and filters for `.gif` files.
+    -   `gisg`: Appends "girls".
+    -   `gist`: Appends "then and now".
+    -   `gisi`: Appends "infographic".
+    -   `gism`: Appends "meme".
+    -   `gisl`: Appends "sexy ladies".
+
+## Getting Started
+
+### Prerequisites
+
+-   [Node.js](https://nodejs.org/) (v18 or later)
+-   [Docker](https://www.docker.com/) (optional, for running in a container)
+
+### Configuration
+
+The application requires the following environment variables to be set:
+
+-   `PORT`: The port for the server to listen on (e.g., `3000`).
+-   `TOKENS`: A comma-separated list of valid Slack tokens for authenticating requests.
+
+You can create a `.env` file in the project root to manage these variables locally:
+
+```
+PORT=3000
+TOKENS=your-slack-token-1,your-slack-token-2
+```
+
+### Building
+
+The project is written in TypeScript and needs to be compiled to JavaScript.
+
+1.  **Install dependencies:**
+    ```bash
+    npm install
+    ```
+
+2.  **Compile the TypeScript code:**
+    The `Dockerfile` uses `npx tsc` to compile the code into the `dist` directory. For local development, you can run the same command or set up your IDE to compile on save.
+
+### Running Locally
+
+After building the project, you can start the server:
+
+```bash
+node dist/index.js
+```
+
+### Running with Docker
+
+A `Dockerfile` is provided for building and running the application in a container.
+
+1.  **Build the Docker image:**
+    ```bash
+    docker build -t gisbot .
+    ```
+
+2.  **Run the Docker container:**
+    ```bash
+    docker run -p 3000:3000 --env-file .env gisbot
+    ```
+    This command maps the container's port to your local machine and passes the environment variables from your `.env` file.
+
+## Development
+
+### Testing
+
+The project uses Jest for testing. To run the test suite:
+
+```bash
+npm test
+```
+
+### Linting
+
+This project uses ESLint for code quality.
+
+-   To check for linting errors:
+    ```bash
+    npm run lint
+    ```
+-   To automatically fix linting errors:
+    ```bash
+    npm run lint:fix
+    ```
+
+### Modifying the Code
+
+This project is built with `effect-ts`, a functional programming library for TypeScript. The core logic is split into several services:
+
+-   `src/parser`: Handles parsing the raw Slack command text.
+-   `src/gis`: Manages scraping Google Image Search results.
+-   `src/server`: Contains the Fastify web server and handles incoming Slack requests.
+
+When making changes, please ensure all tests pass and the code is properly linted.

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -5,7 +5,7 @@ const run = (s: string) => getSearchTextAndIndex(s).pipe(Option.getOrUndefined);
 
 describe("parser", () => {
   it("all options work", () => {
-    expect(run("gisa42    xyz  ")).toEqual({ index: 42, text: "xyz animated gif" });
+    expect(run("gisa42    xyz  ")).toEqual({ index: 42, mod: "a", text: "xyz animated gif" });
   });
 
   it.each([

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,6 +1,6 @@
 import { Match, Option, pipe } from "effect";
 
-type Mod = "g" | "t" | "i" | "a" | "m" | "l" | undefined;
+export type Mod = "g" | "t" | "i" | "a" | "m" | "l" | undefined;
 const re = /^gis([gtiaml])?(\d+)? (.+)/i;
 
 const parseNum = (n: string | undefined) =>

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -18,6 +18,7 @@ export const getSearchTextAndIndex = (messageText: string) =>
     Option.filter(x => !!x.search.length),
     Option.andThen(({ mod, idx, search }) => ({
       index: idx ?? 1,
+      mod,
       text: `${search}${Match.value(mod).pipe(
         Match.when(undefined, () => ""),
         Match.when("g", () => " girls"),

--- a/src/server/service.test.ts
+++ b/src/server/service.test.ts
@@ -6,7 +6,7 @@ const { doSearch } = forTesting;
 describe("server", () => {
   it("doSearch returns proper elapsed time", () =>
     Effect.gen(function* () {
-      const fiber = yield* doSearch("a", 1, {
+      const fiber = yield* doSearch("a", 1, undefined, {
         gis: () => Effect.succeed([{ url: "a", width: 1, height: 1 }]).pipe(Effect.delay("500 millis")),
       }).pipe(Effect.fork);
 
@@ -16,4 +16,18 @@ describe("server", () => {
 
       expect(res.elapsed.pipe(Duration.toMillis)).toEqual(500);
     }).pipe(Effect.provide(TestContext.TestContext), Effect.runPromise));
+
+  it("doSearch with 'a' mod filters for gifs", () =>
+    Effect.gen(function* () {
+      const res = yield* doSearch("a", 1, "a", {
+        gis: () =>
+          Effect.succeed([
+            { url: "a.jpg", width: 1, height: 1 },
+            { url: "b.gif", width: 1, height: 1 },
+            { url: "c.png", width: 1, height: 1 },
+          ]),
+      });
+
+      expect(res.result?.url).toEqual("b.gif");
+    }).pipe(Effect.runPromise));
 });

--- a/src/server/service.ts
+++ b/src/server/service.ts
@@ -15,11 +15,13 @@ class InvalidSearch {
 const BadDomains =
   /(alamy\.com)|(depositphotos\.com)|(shutterstock\.com)|(maps\.google\.com)|(fbsbx.*\.com)|(memegenerator.*\.net)|(gstatic.*\.com)|(instagram.*\.com)|(tiktok.*\.com)/i;
 
-const doSearch = (text: string, index: number, giser: GISerFuncs) =>
+const doSearch = (text: string, index: number, mod: "g" | "t" | "i" | "a" | "m" | "l" | undefined, giser: GISerFuncs) =>
   pipe(
     Effect.timed(giser.gis(text)),
     Effect.andThen(([elapsed, result]) => ({
-      result: result.filter(r => !r.url.match(BadDomains))[index - 1],
+      result: result.filter(r => !r.url.match(BadDomains)).filter(r => (mod === "a" ? r.url.endsWith(".gif") : true))[
+        index - 1
+      ],
       elapsed,
     })),
   );
@@ -110,7 +112,7 @@ export const ServerLive = Layer.effect(
                             Effect.catchTag("NoSuchElementException", () => Effect.fail(new InvalidSearch())),
                             Effect.tap(parsed => Effect.logInfo(`calling with search text: '${parsed.text}'`)),
                             Effect.tap(stats.pipe(Ref.update(s => ({ ...s, totalSearches: 1 + s.totalSearches })))),
-                            Effect.andThen(({ text, index }) => doSearch(text, index, giser)),
+                            Effect.andThen(({ text, index, mod }) => doSearch(text, index, mod, giser)),
                             Effect.andThen(({ result, elapsed }) =>
                               result === undefined
                                 ? unknown

--- a/src/server/service.ts
+++ b/src/server/service.ts
@@ -3,7 +3,7 @@ import { Context, Duration, Effect, HashSet, Layer, pipe, Ref } from "effect";
 import Fastify from "fastify";
 import { Config } from "../config";
 import { GISer, GISerFuncs } from "../gis";
-import { getSearchTextAndIndex } from "../parser";
+import { getSearchTextAndIndex, Mod } from "../parser";
 
 type Stats = Readonly<{ totalSearches: number; totalFailures: number }>;
 const emptyStats = (): Stats => ({ totalFailures: 0, totalSearches: 0 });
@@ -15,7 +15,7 @@ class InvalidSearch {
 const BadDomains =
   /(alamy\.com)|(depositphotos\.com)|(shutterstock\.com)|(maps\.google\.com)|(fbsbx.*\.com)|(memegenerator.*\.net)|(gstatic.*\.com)|(instagram.*\.com)|(tiktok.*\.com)/i;
 
-const doSearch = (text: string, index: number, mod: "g" | "t" | "i" | "a" | "m" | "l" | undefined, giser: GISerFuncs) =>
+const doSearch = (text: string, index: number, mod: Mod, giser: GISerFuncs) =>
   pipe(
     Effect.timed(giser.gis(text)),
     Effect.andThen(([elapsed, result]) => ({


### PR DESCRIPTION
feat: Filter gisa results for GIFs and improve documentation

This commit introduces a key improvement to the 'gisa' (animated gif) search functionality. Previously, a 'gisa' search could return non-GIF image types. Now, the results are explicitly filtered to ensure only images with a .gif extension are returned.

Key changes:
- The command parser in `src/parser/index.ts` has been updated to include the search modifier (e.g., 'a' for 'gisa') in its output.
- The server logic in `src/server/service.ts` now uses this modifier to apply a .gif file extension filter on the results from Google Image Search for all 'gisa' commands.
- Added a new test case to `src/server/service.test.ts` to verify the GIF filtering behavior.
- Updated existing parser tests to align with the new return structure.

Additionally, the project's README.md has been significantly expanded with detailed sections on:
- Features and command modifiers
- Configuration and environment variables
- Instructions for building, running (locally and with Docker), and testing
- An overview of the codebase for new developers.