### PR TITLE
feat: blacklist yarn.co from image search results

### DIFF
--- a/src/gis/service.test.ts
+++ b/src/gis/service.test.ts
@@ -1,0 +1,42 @@
+import { Effect } from "effect";
+import { GISer, GISerLive } from "./service";
+
+describe("GISer", () => {
+  it("includes blacklisted domains in search query", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch").mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        arrayBuffer: () => Promise.resolve(Buffer.from("")),
+      } as unknown as Response),
+    );
+
+    const program = Effect.gen(function* (_) {
+      const giser = yield* _(GISer);
+      yield* _(giser.gis("test query"));
+    }).pipe(Effect.provide(GISerLive));
+
+    // We expect it to potentially fail due to empty response parsing, but we check the fetch call
+    await Effect.runPromise(program).catch(() => {});
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const call = fetchSpy.mock.calls[0];
+    if (!call) {
+      throw new Error("Fetch was not called");
+    }
+    const url = call[0] as string;
+
+    // Check that the URL contains the encoded query
+    // " -site:yarn.co" encodes to something like "%20-site%3Ayarn.co"
+    // But we can check for the decoded version or just part of it if querystring encodes it.
+    // node:querystring encodes spaces as %20 or + depending on implementation, and : as %3A
+
+    // Let's print the URL to be sure if the test fails, but generally we expect the blacklist logic to be present.
+    // simpler to check if "yarn.co" is present in the URL string, regardless of encoding,
+    // but better to match the specific site exclusion param pattern.
+
+    expect(url).toContain("yarn.co");
+    expect(url).toContain("gstatic.com");
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/src/gis/service.ts
+++ b/src/gis/service.ts
@@ -28,7 +28,7 @@ const UserAgent =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36";
 
 const ImageFileExtensions = [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg"];
-const FilterDomains = ["gstatic.com"].map(domain => ` -site:${domain}`).join(" ");
+const FilterDomains = ["gstatic.com", "yarn.co"].map(domain => ` -site:${domain}`).join(" ");
 
 const ImageURLRegex = /\["(http.+?)",(\d+),(\d+)]/g;
 


### PR DESCRIPTION
Blacklists yarn.co from image search results to improve quality. Includes unit test verification.