### PR TITLE
Blacklist yarn.co domain

### DIFF
--- a/src/server/service.test.ts
+++ b/src/server/service.test.ts
@@ -30,4 +30,17 @@ describe("server", () => {
 
       expect(res.result?.url).toEqual("b.gif");
     }).pipe(Effect.runPromise));
+
+  it("doSearch filters out bad domains", () =>
+    Effect.gen(function* () {
+      const res = yield* doSearch("a", 1, undefined, {
+        gis: () =>
+          Effect.succeed([
+            { url: "https://yabbadabbadoo.yarn.co/image.jpg", width: 1, height: 1 },
+            { url: "https://other.com/image.jpg", width: 1, height: 1 },
+          ]),
+      });
+
+      expect(res.result?.url).toEqual("https://other.com/image.jpg");
+    }).pipe(Effect.runPromise));
 });

--- a/src/server/service.ts
+++ b/src/server/service.ts
@@ -13,7 +13,7 @@ class InvalidSearch {
 }
 
 const BadDomains =
-  /(alamy\.com)|(depositphotos\.com)|(shutterstock\.com)|(maps\.google\.com)|(fbsbx.*\.com)|(memegenerator.*\.net)|(gstatic.*\.com)|(instagram.*\.com)|(tiktok.*\.com)/i;
+  /(alamy\.com)|(depositphotos\.com)|(shutterstock\.com)|(maps\.google\.com)|(fbsbx.*\.com)|(memegenerator.*\.net)|(gstatic.*\.com)|(instagram.*\.com)|(tiktok.*\.com)|(yarn\.co)/i;
 
 const doSearch = (text: string, index: number, mod: Mod, giser: GISerFuncs) =>
   pipe(


### PR DESCRIPTION
This PR adds yarn.co to the BadDomains regex in src/server/service.ts to ensure image search results from this domain are filtered out. It also adds a unit test to verify this filtering logic.