### PR TITLE
fix(gis): bypass Google bot detection and improve extraction

### DIFF
--- a/src/gis/service.test.ts
+++ b/src/gis/service.test.ts
@@ -1,0 +1,45 @@
+import { JSDOM } from "jsdom";
+import { parseImages } from "./service";
+
+describe("GISer", () => {
+  it("parseImages extracts images correctly from script tags", () => {
+    const html = `
+      <html>
+        <body>
+          <script>
+            const data = [["https://example.com/image1.jpg",100,200],["https://example.com/image2.png",300,400]];
+          </script>
+          <script>
+            var x = ["https://example.com/image3.gif",500,600];
+          </script>
+        </body>
+      </html>
+    `;
+    const dom = new JSDOM(html);
+    const results = parseImages(dom);
+
+    expect(results).toHaveLength(3);
+    expect(results[0]).toEqual({ url: "https://example.com/image1.jpg", width: 200, height: 100 });
+    expect(results[1]).toEqual({ url: "https://example.com/image2.png", width: 400, height: 300 });
+    expect(results[2]).toEqual({ url: "https://example.com/image3.gif", width: 600, height: 500 });
+  });
+
+  it("parseImages handles modern JSON embedding (all scripts scanned)", () => {
+    const html = `
+      <html>
+        <body>
+          <script>
+            // A script without extensions in plain text, but with JSON data
+            // This is what the fix is intended to handle
+            const data = [["https://example.com/image_without_extension",100,200]];
+          </script>
+        </body>
+      </html>
+    `;
+    const dom = new JSDOM(html);
+    const results = parseImages(dom);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({ url: "https://example.com/image_without_extension", width: 200, height: 100 });
+  });
+});

--- a/src/gis/service.ts
+++ b/src/gis/service.ts
@@ -23,24 +23,20 @@ export type GISerFuncs = Readonly<{
 
 export class GISer extends Context.Tag("GISer")<GISer, GISerFuncs>() {}
 
-const BaseUrl = "https://images.google.com/search";
-const UserAgent =
-  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36";
+const BaseUrl = "https://www.google.com/search";
+const UserAgent = "AdsBot-Google (+http://www.google.com/adsbot.html)";
 
-const ImageFileExtensions = [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg"];
 const FilterDomains = ["gstatic.com"].map(domain => ` -site:${domain}`).join(" ");
 
 const ImageURLRegex = /\["(http.+?)",(\d+),(\d+)]/g;
 
 type ImageResult = Readonly<{ url: string; width: number; height: number }>;
 
-const parseImages = (dom: JSDOM): readonly ImageResult[] => {
+export const parseImages = (dom: JSDOM): readonly ImageResult[] => {
   const scripts = Array.from(dom.window.document.querySelectorAll("script"));
-  const containsExtensions = scripts
-    .filter(s => ImageFileExtensions.some(ext => s.innerHTML.includes(ext)))
-    .map(s => s.innerHTML);
+  const scriptsContent = scripts.map(s => s.innerHTML);
 
-  return containsExtensions.flatMap(script =>
+  return scriptsContent.flatMap(script =>
     Array.from(script.matchAll(ImageURLRegex)).reduce((acc, result) => {
       if (result.length <= 3) return acc;
       else {


### PR DESCRIPTION
Bypass Google's bot detection by switching User-Agent and updating extraction logic.